### PR TITLE
Add projections to MapPlot

### DIFF
--- a/examples/example_08.py
+++ b/examples/example_08.py
@@ -1,0 +1,30 @@
+from datetime import datetime
+from pytz import timezone
+from starplot import MapPlot, Projection
+from starplot.styles import PlotStyle, extensions, MarkerSymbolEnum
+
+style = PlotStyle().extend(
+    extensions.BLUE_MEDIUM,
+    extensions.MAP,
+)
+
+tz = timezone("Europe/Amsterdam")
+dt = datetime(2024, 1, 20, 22, 00, tzinfo=tz)  # July 13, 2023 at 10pm PT
+lat, lon = (52.377956, 4.897070)
+
+p = MapPlot(
+    projection=Projection.ORTHOGRAPHIC,
+    lat=lat,
+    lon=lon,
+    dt=dt,
+    ra_min=0,
+    ra_max=24,
+    dec_min=-90,
+    dec_max=90,
+    limiting_magnitude=3.6,
+    style=style,
+    resolution=1400,
+    dso_types=[],  # this is one way to hide all deep sky objects
+)
+
+p.export("08_orthographic.png", padding=0.2)

--- a/examples/example_09.py
+++ b/examples/example_09.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+from pytz import timezone
+from starplot import MapPlot, Projection
+from starplot.styles import PlotStyle, extensions, MarkerSymbolEnum
+
+style = PlotStyle().extend(
+    extensions.BLUE_MEDIUM,
+    extensions.MAP,
+)
+
+tz = timezone("Europe/Amsterdam")
+dt = datetime(2024, 1, 20, 22, 00, tzinfo=tz)  # July 13, 2023 at 10pm PT
+
+# With a Stereographic projection you can set the center point
+# With STEREO_NORTH it is the northpole
+# With STEREO_SOUTH it is the south pole
+# here you cn choose here it is set on the equator
+# note tha this center of the projection can be outside of the map bounds you set
+p = MapPlot(
+    projection=Projection.STEREOGRAPHIC,
+    lat=0,
+    lon=0,
+    dt = dt,
+    ra_min=0,
+    ra_max=6,
+    dec_min=-40,
+    dec_max=60,
+    limiting_magnitude=3.6,
+    style=style,
+    resolution=1400,
+    dso_types=[],  # this is one way to hide all deep sky objects
+)
+
+p.plot_horizon() # plot a circle on the map where the horizon is for this (lat, lon)
+p.export("09_stereographic.png", padding=0.2)

--- a/examples/example_10.py
+++ b/examples/example_10.py
@@ -1,0 +1,32 @@
+from datetime import datetime
+from pytz import timezone
+from starplot import MapPlot, Projection
+from starplot.styles import PlotStyle, extensions, MarkerSymbolEnum
+
+style = PlotStyle().extend(
+    extensions.BLUE_MEDIUM,
+    extensions.MAP,
+)
+
+tz = timezone("Europe/Amsterdam")
+dt = datetime(2024, 1, 20, 22, 00, tzinfo=tz)  # July 13, 2023 at 10pm PT
+lat, lon = (52.377956, 4.897070)
+
+# create a Zenith Plot using MapPlot so you can have constellation borders and milky way
+p = MapPlot(
+    projection=Projection.ZENITH,
+    lat=lat,
+    lon=lon,
+    dt=dt,
+    ra_min=0,
+    ra_max=24,
+    dec_min=-90,
+    dec_max=90,
+    limiting_magnitude=3.6,
+    style=style,
+    resolution=1400,
+    dso_types=[],  # this is one way to hide all deep sky objects
+)
+
+p.plot_horizon() # plot a circle on the map where the horizon is for this (lat, lon)
+p.export("10_zenith.png", padding=0.2)

--- a/src/starplot/projections.py
+++ b/src/starplot/projections.py
@@ -21,6 +21,15 @@ class Projection(str, Enum):
     MILLER = "miller"
     """Similar to Mercator: good for declinations between -70 and 70, but distorts objects near the poles"""
 
+    ORTHOGRAPHIC = "orthographic"
+    """Test"""
+
+    STEREOGRAPHIC = "stereographic"
+    """Test"""
+
+    ZENITH = "zenith"
+    """Test"""
+
     @staticmethod
     def crs(projection, center_lon=-180, **kwargs):
         projections = {
@@ -29,6 +38,12 @@ class Projection(str, Enum):
             Projection.MERCATOR: ccrs.Mercator,
             Projection.MOLLWEIDE: ccrs.Mollweide,
             Projection.MILLER: ccrs.Miller,
+            Projection.ORTHOGRAPHIC: ccrs.Orthographic,
+            Projection.STEREOGRAPHIC: ccrs.Stereographic,
+            Projection.ZENITH: ccrs.Stereographic
         }
         proj_class = projections.get(projection)
-        return proj_class(center_lon, **kwargs)
+        if projection in [Projection.ORTHOGRAPHIC, Projection.STEREOGRAPHIC,Projection.ZENITH]:
+            return proj_class(central_longitude=kwargs['lon'], central_latitude=kwargs['lat'])
+        else:
+            return proj_class(center_lon, **kwargs)


### PR DESCRIPTION
Add following projections to MapPlot
- ORTHOGRAPHIC
- STEREOGRAPHIC (similar to STEREO_NORTH and STEREO_SOUTH but you set the center of the projection)
- ZENITH (Stereographic centered on your own location show visible sky)

added examples for each
- in zenith plot the dotted red line is the horizon