### PR TITLE
Basic usage fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,12 @@ To create a star chart for tonight's sky as seen from [Palomar Mountain](https:/
 ```python
 from datetime import datetime
 from pytz import timezone
-from starplot.map import Projection
 import starplot as sp
 
 tz = timezone("America/Los_Angeles")
 
 p = sp.MapPlot(
-    projection=Projection.ZENITH,
+    projection=sp.Projection.ZENITH,
     lat=33.363484,
     lon=-116.836394,
     dt=datetime.now(tz).replace(hour=22),

--- a/README.md
+++ b/README.md
@@ -31,12 +31,13 @@ To create a star chart for tonight's sky as seen from [Palomar Mountain](https:/
 ```python
 from datetime import datetime
 from pytz import timezone
+from starplot.map import Projection
 import starplot as sp
 
 tz = timezone("America/Los_Angeles")
 
 p = sp.MapPlot(
-    projection=sp.Projection.ZENITH,
+    projection=Projection.ZENITH,
     lat=33.363484,
     lon=-116.836394,
     dt=datetime.now(tz).replace(hour=22),

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ import starplot as sp
 tz = timezone("America/Los_Angeles")
 
 p = sp.MapPlot(
-    projection=Projection.ZENITH,
+    projection=sp.Projection.ZENITH,
     lat=33.363484,
     lon=-116.836394,
     dt=datetime.now(tz).replace(hour=22),


### PR DESCRIPTION
When following the documentation for Starplot's installation (MacOS), then using the provided Basic Usage code I got a NameError for Projection.ZENITH. Added import statement to properly access `Projection`.

Python version: 3.12.2

<img width="653" alt="Screenshot 2024-03-23 at 12 44 49 PM" src="https://github.com/HamBoneGS/starplot/assets/59839249/8938572a-25fe-40d7-99a6-bffa21353f00">
