### PR TITLE
v0.10.2

### DIFF
--- a/hash_checks/hashlock.yml
+++ b/hash_checks/hashlock.yml
@@ -23,9 +23,9 @@ map_orion_base:
   filename: /starplot/hash_checks/data/map-orion-base.png
   phash: be79d9260785709c
 map_orion_extra:
-  dhash: 1c1b1a7d2d646c061c1b1a6b2d646c061c1b1b6b6f246c06
+  dhash: 1c1b3a7d2d646c171c1b3a6b2d646c871c1b1b6b2f246c07
   filename: /starplot/hash_checks/data/map-orion-extra.png
-  phash: be71d11ee01fe490
+  phash: be71d11ee01fa4d0
 map_scope_bino_fov:
   dhash: 0bc080848c8080802bceb2ac4daa928c2bceb2ac4daa928c
   filename: /starplot/hash_checks/data/map-scope-bino-fov.png
@@ -95,6 +95,6 @@ optic_wrapping:
   filename: /starplot/hash_checks/data/optic-wrapping.png
   phash: d0c46f1b396cf078
 zenith_base:
-  dhash: 1379cca69a9479271359acae9a9479271359ac868a947927
+  dhash: 1359ac8abad4690e1359ac8a82d4690e1359ac8a82dc6906
   filename: /starplot/hash_checks/data/zenith-base.png
-  phash: 90db3bb961366472
+  phash: b051fb3be12cb464

--- a/hash_checks/zenith_checks.py
+++ b/hash_checks/zenith_checks.py
@@ -31,9 +31,7 @@ def _zenith():
     p.constellations()
     p.ecliptic(style__line__width=8)
     p.celestial_equator(style__line__width=8)
-    p.legend(
-        style__location=styles.LegendLocationEnum.OUTSIDE_BOTTOM
-    )
+    p.legend(style__location=styles.LegendLocationEnum.OUTSIDE_BOTTOM)
     return p
 
 

--- a/hash_checks/zenith_checks.py
+++ b/hash_checks/zenith_checks.py
@@ -31,6 +31,9 @@ def _zenith():
     p.constellations()
     p.ecliptic(style__line__width=8)
     p.celestial_equator(style__line__width=8)
+    p.legend(
+        style__location=styles.LegendLocationEnum.OUTSIDE_BOTTOM
+    )
     return p
 
 

--- a/src/starplot/__init__.py
+++ b/src/starplot/__init__.py
@@ -1,6 +1,6 @@
 """Star charts and maps"""
 
-__version__ = "0.10.1"
+__version__ = "0.10.2"
 
 from .base import BasePlot  # noqa: F401
 from .map import MapPlot, Projection  # noqa: F401

--- a/src/starplot/base.py
+++ b/src/starplot/base.py
@@ -225,7 +225,7 @@ class BasePlot(ABC):
         if style.location == LegendLocationEnum.OUTSIDE_BOTTOM:
             style.location = "lower center"
             offset_y = -0.08
-            if getattr(self, '_axis_labels', False):
+            if getattr(self, "_axis_labels", False):
                 offset_y -= 0.05
             bbox_kwargs = dict(
                 bbox_to_anchor=(0.5, offset_y),
@@ -234,7 +234,7 @@ class BasePlot(ABC):
         elif style.location == LegendLocationEnum.OUTSIDE_TOP:
             style.location = "upper center"
             offset_y = 1.08
-            if getattr(self, '_axis_labels', False):
+            if getattr(self, "_axis_labels", False):
                 offset_y += 0.05
             bbox_kwargs = dict(
                 bbox_to_anchor=(0.5, offset_y),

--- a/src/starplot/base.py
+++ b/src/starplot/base.py
@@ -214,30 +214,33 @@ class BasePlot(ABC):
         Args:
             style: Styling of the legend. If None, then the plot's style (specified when creating the plot) will be used
         """
-        if not self._legend_handles:
-            return
-
         if self._legend is not None:
             self._legend.remove()
+
+        if not self._legend_handles:
+            return
 
         bbox_kwargs = {}
 
         if style.location == LegendLocationEnum.OUTSIDE_BOTTOM:
-            # to plot legends outside the map area, you have to target the figure
-            target = self.fig
+            style.location = "lower center"
+            offset_y = -0.08
+            if getattr(self, '_axis_labels', False):
+                offset_y -= 0.05
             bbox_kwargs = dict(
-                bbox_to_anchor=(0.5, 0.13), bbox_transform=self.fig.transFigure
+                bbox_to_anchor=(0.5, offset_y),
             )
 
         elif style.location == LegendLocationEnum.OUTSIDE_TOP:
-            target = self.fig
+            style.location = "upper center"
+            offset_y = 1.08
+            if getattr(self, '_axis_labels', False):
+                offset_y += 0.05
             bbox_kwargs = dict(
-                bbox_to_anchor=(0.5, 0.87), bbox_transform=self.fig.transFigure
+                bbox_to_anchor=(0.5, offset_y),
             )
-        else:
-            target = self.ax
 
-        self._legend = target.legend(
+        self._legend = self.ax.legend(
             handles=self._legend_handles.values(),
             **style.matplot_kwargs(size_multiplier=self._size_multiplier),
             **bbox_kwargs,

--- a/src/starplot/base.py
+++ b/src/starplot/base.py
@@ -22,6 +22,7 @@ from starplot.styles import (
     LabelStyle,
     LegendLocationEnum,
     LegendStyle,
+    MarkerSymbolEnum,
     PathStyle,
     PolygonStyle,
 )
@@ -388,7 +389,7 @@ class BasePlot(ABC):
 
         Args:
             style: Styling of the Sun. If None, then the plot's style (specified when creating the plot) will be used
-            true_size: If True, then the Sun's true apparent size in the sky will be plotted. If False, then the style's marker size will be used.
+            true_size: If True, then the Sun's true apparent size in the sky will be plotted as a circle (the marker style's symbol will be ignored). If False, then the style's marker size will be used.
             label: How the Sun will be labeled on the plot and legend
         """
         s = models.Sun.get(
@@ -413,6 +414,7 @@ class BasePlot(ABC):
                 style=polygon_style,
             )
 
+            style.marker.symbol = MarkerSymbolEnum.CIRCLE
             self._add_legend_handle_marker(legend_label, style.marker)
 
             if label:
@@ -584,7 +586,7 @@ class BasePlot(ABC):
 
         Args:
             style: Styling of the Moon. If None, then the plot's style (specified when creating the plot) will be used
-            true_size: If True, then the Moon's true apparent size in the sky will be plotted. If False, then the style's marker size will be used.
+            true_size: If True, then the Moon's true apparent size in the sky will be plotted as a circle (the marker style's symbol will be ignored). If False, then the style's marker size will be used.
             show_phase: If True, and if `true_size = True`, then the approximate phase of the moon will be illustrated. The dark side of the moon will be colored with the marker's `edge_color`.
             label: How the Moon will be labeled on the plot and legend
         """
@@ -620,6 +622,7 @@ class BasePlot(ABC):
                     style=polygon_style,
                 )
 
+            style.marker.symbol = MarkerSymbolEnum.CIRCLE
             self._add_legend_handle_marker(legend_label, style.marker)
 
             if label:

--- a/src/starplot/map.py
+++ b/src/starplot/map.py
@@ -517,6 +517,9 @@ class MapPlot(BasePlot, ExtentMaskMixin, StarPlotterMixin, DsoPlotterMixin):
             **style.line.matplot_kwargs(),
         )
 
+        if labels:
+            self._axis_labels = True
+    
         style_kwargs = style.label.matplot_kwargs()
         style_kwargs.pop("va")
         style_kwargs.pop("ha")

--- a/src/starplot/map.py
+++ b/src/starplot/map.py
@@ -519,7 +519,7 @@ class MapPlot(BasePlot, ExtentMaskMixin, StarPlotterMixin, DsoPlotterMixin):
 
         if labels:
             self._axis_labels = True
-    
+
         style_kwargs = style.label.matplot_kwargs()
         style_kwargs.pop("va")
         style_kwargs.pop("ha")


### PR DESCRIPTION
Fixes:
- When sun/moon are plotted as true size, the legend marker should be a circle
- Legend location on zenith charts `"outside lower center"` plotting inside the chart