### PR TITLE
data/raw/translations/zh-cn/constellation_names.csv

### DIFF
--- a/data/raw/translations/zh-cn/constellation_names.csv
+++ b/data/raw/translations/zh-cn/constellation_names.csv
@@ -8,27 +8,27 @@ ara,Ara,天坛
 ari,Aries,白羊
 aur,Auriga,御夫
 boo,Bootes,牧夫
-cae,Caelum,大犬
-cam,Camelopardalis,小犬
-cap,Capricornus,猎犬
-car,Carina,雕具
-cas,Cassiopeia,鹿豹
-cen,Centaurus,摩羯
-cep,Cepheus,船底
-cet,Cetus,仙后
-cha,Chamaeleon,半人马
-cir,Circinus,仙王
-cma,Canis Major,鲸鱼
-cmi,Canis Minor,蝘蜓
-cnc,Cancer,圆规
-col,Columba,巨蟹
-com,Coma Berenices,天鸽
-cra,Corona Australis,后发
-crb,Corona Borealis,南冕
-crt,Crater,北冕
-cru,Crux,巨爵
-crv,Corvus,南十字
-cvn,Canes Venatici,乌鸦
+cae,Caelum,雕具
+cam,Camelopardalis,鹿豹
+cap,Capricornus,摩羯
+car,Carina,船底
+cas,Cassiopeia,仙后
+cen,Centaurus,半人马
+cep,Cepheus,仙王
+cet,Cetus,鲸鱼
+cha,Chamaeleon,蝘蜓
+cir,Circinus,圆规
+cma,Canis Major,大犬
+cmi,Canis Minor,小犬
+cnc,Cancer,巨蟹
+col,Columba,天鸽
+com,Coma Berenices,后发
+cra,Corona Australis,南冕
+crb,Corona Borealis,北冕
+crt,Crater,巨爵
+cru,Crux,南十字
+crv,Corvus,乌鸦
+cvn,Canes Venatici,猎犬
 cyg,Cygnus,天鹅
 del,Delphinus,海豚
 dor,Dorado,剑鱼
@@ -43,11 +43,11 @@ hor,Horologium,时钟
 hya,Hydra,长蛇
 hyi,Hydrus,水蛇
 ind,Indus,印第安
-lac,Lacerta,小狮
-leo,Leo,蝎虎
-lep,Lepus,狮子
-lib,Libra,天兔
-lmi,Leo Minor,天秤
+lac,Lacerta,蝎虎
+leo,Leo,狮子
+lep,Lepus,天兔
+lib,Libra,天秤
+lmi,Leo Minor,小狮
 lup,Lupus,豺狼
 lyn,Lynx,天猫
 lyr,Lyra,天琴


### PR DESCRIPTION
[data/raw/translations/zh-cn/constellation_names.csv](https://github.com/hongming/starplot/commit/34345ebe3d4b9ff4116f7f3f164677ae9dfbd9a5#diff-703b48ede1d7bba3fbf297fdee56929dbbb05a54e3ffb66c2faa2f72e44a8e33)

This commit resolves a data misalignment that caused incorrect Chinese labels for constellations in two ranges:

From cae to cvn

From lac to lmi

Example: cma was erroneously labeled "鲸鱼" instead of "大犬".

The provided file now contains accurate and ready-to-use Chinese names.