### PR TITLE
Add mpl trove classifier to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "Framework :: Matplotlib"
+    "Framework :: Matplotlib",
 ]
 dynamic = ["version", "description"]
 keywords = ["astronomy", "stars", "charts", "maps", "constellations", "sky", "plotting"]


### PR DESCRIPTION
Hi, 
Since you mentioned Starplot in https://github.com/matplotlib/matplotlib/pull/30960, figured you might be interested in identifying the project as an mpl downstream library on PyPI via the trove classifier. Also please consider your very cool library to https://matplotlib.org/thirdpartypackages/