### PR TITLE
fix: install DuckDB spatial extension before loading it

### DIFF
--- a/src/starplot/cli.py
+++ b/src/starplot/cli.py
@@ -12,7 +12,6 @@ def setup(options):
     print("Installing DuckDB spatial extension...")
 
     con = db.connect()
-    con.load_extension("spatial")
 
     fonts.load()
 

--- a/src/starplot/data/db.py
+++ b/src/starplot/data/db.py
@@ -15,6 +15,7 @@ def connect():
     connection = duckdb.connect()
     path = settings.data_path / "duckdb-extensions"
     connection.raw_sql(f"SET extension_directory = '{str(path)}';")
+    connection.raw_sql("INSTALL spatial;")
     connection.load_extension("spatial")
 
     missing_name_tables = set(NAME_TABLES.keys()) - set(connection.list_tables())


### PR DESCRIPTION
## Problem

\db.connect()\ calls \load_extension('spatial')\ but never calls \INSTALL spatial\ first. In fresh environments or Jupyter notebooks, the spatial extension isn't cached, causing:

\\\
CatalogException: Catalog Error: Scalar Function with name 'st_point' is not in the catalog,
but it exists in the spatial extension.
\\\

## Fix

- **\db.py\**: Added \INSTALL spatial\ before \load_extension('spatial')\ in \connect()\. DuckDB's \INSTALL\ is a no-op if already installed, so this is safe to call every time.
- **\cli.py\**: Removed redundant \con.load_extension('spatial')\ in \setup()\ since \db.connect()\ already handles both install and load.

## Testing

Verified that \ST_Point()\ works correctly after the fix:

\\\python
from starplot.data import db
con = db.connect()
result = con.raw_sql('SELECT ST_Point(1.0, 2.0) as pt')
# Works without error
\\\

Fixes #175