### PR TITLE
Continuous moon phase illumination

### DIFF
--- a/src/starplot/plots/base.py
+++ b/src/starplot/plots/base.py
@@ -785,7 +785,7 @@ class BasePlot(DebugPlotterMixin, TextPlotterMixin, ABC):
         radius_degrees: float,
         style: PolygonStyle,
         dark_side_color: str,
-        num_pts: int = 100,
+        num_pts: int = 200,
     ):
         """
         Plots the (approximate) moon phase by drawing two half circles and one ellipse in the center,


### PR DESCRIPTION
The information was already available. Just implemented a variable `b` radius for the central `ellipse()`. This is calculated by getting the ratio between the full circle (two half-circles) area minus the central ellipse() 

$$
A_{\text{ellipse}} = \pi a b ; A_{\text{circle}} = \pi r^2; a=r
$$

$$
\frac{A_{\text{circle}} - A_{\text{ellipse}}}{2 A_{\text{circle}}} = \text{moon percentage}
$$

$$
b = r (2 \times \text{moon percentage} - 1)
$$

Always taking the absolute value as $b = -b$

Also added `num_pts` for the central `ellipse()` and increased the default from $100$ to $200$ due to graphical glitch when illumination is around $50$%

Examples:

<img width="363" height="313" alt="image" src="https://github.com/user-attachments/assets/8b9a1e88-f017-4de1-8dee-81123fd69b1c" />
<img width="378" height="306" alt="image" src="https://github.com/user-attachments/assets/cd0befc3-76ed-44ae-9bfa-fe40b1f461a4" />
<img width="457" height="345" alt="image" src="https://github.com/user-attachments/assets/45741012-ee6f-4d50-a833-75ac5b3caa9f" />
<img width="359" height="300" alt="image" src="https://github.com/user-attachments/assets/b09151c2-4d81-42b2-b064-683042b251ed" />
<img width="335" height="311" alt="image" src="https://github.com/user-attachments/assets/ebb46288-37ca-4e0f-b42d-2dbbe9a4f356" />